### PR TITLE
invalid space characted in request

### DIFF
--- a/checkLocalIP_updateRoute53.py
+++ b/checkLocalIP_updateRoute53.py
@@ -68,7 +68,7 @@ if match != True:
 	                    'TTL': TTL,
 	                    'ResourceRecords': [
         	                {
-                	            'Value': localIP
+                	            'Value':localIP
                         	},
 	                        ],
         	            }


### PR DESCRIPTION
removing the space to fix the following error:
botocore.errorfactory.InvalidChangeBatch: An error occurred (InvalidChangeBatch) when calling the ChangeResourceRecordSets operation: [Invalid Resource Record: FATAL problem: ARRDATANotSingleFie ld (Value contains spaces) encountered with '<html>